### PR TITLE
feat: case insensitive sorting mode XT-41729

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -17,6 +17,6 @@ jobs:
               with:
                   node-version: 20
             - name: Install Dependencies
-            - run: npm ci
+              run: npm ci
             - name: Run tests
               run: npm run build

--- a/spec/generic/collection.spec.js
+++ b/spec/generic/collection.spec.js
@@ -1,13 +1,13 @@
 var loki = require('../../src/lokijs');
 
 describe('collection', function () {
-  it('collection rename works', function() {
+  it('collection rename works', function () {
     var db = new loki('test.db');
     var coll = db.addCollection('coll1');
-    
+
     var result = db.getCollection('coll1');
     expect(result.name).toEqual('coll1');
-    
+
     db.renameCollection('coll1', 'coll2');
     result = db.getCollection('coll1');
     expect(result).toBeNull();
@@ -22,7 +22,7 @@ describe('collection', function () {
     SubclassedCollection.prototype = new loki.Collection;
     SubclassedCollection.prototype.extendedMethod = function () {
       return this.name.toUpperCase();
-    }
+    };
     var coll = new SubclassedCollection('users', {});
 
     expect(coll != null).toBe(true);
@@ -33,27 +33,27 @@ describe('collection', function () {
     expect(coll.data.length).toEqual(1);
   });
 
-  it('findAndUpdate works', function() {
+  it('findAndUpdate works', function () {
     var db = new loki('test.db');
     var coll = db.addCollection('testcoll');
-    coll.insert([{ a:3, b:3 }, { a:6, b:7 }, { a:1, b:2 }, { a:7, b:8 }, { a:6, b: 4}]);
+    coll.insert([{ a: 3, b: 3 }, { a: 6, b: 7 }, { a: 1, b: 2 }, { a: 7, b: 8 }, { a: 6, b: 4 }]);
 
-    coll.findAndUpdate({a:6}, function(obj) {
+    coll.findAndUpdate({ a: 6 }, function (obj) {
       obj.b += 1;
     });
 
-    var result = coll.chain().find({a:6}).simplesort("b").data();
+    var result = coll.chain().find({ a: 6 }).simplesort("b").data();
     expect(result.length).toEqual(2);
     expect(result[0].b).toEqual(5);
     expect(result[1].b).toEqual(8);
   });
 
-  it('findAndRemove works', function() {
+  it('findAndRemove works', function () {
     var db = new loki('test.db');
     var coll = db.addCollection('testcoll');
-    coll.insert([{ a:3, b:3 }, { a:6, b:7 }, { a:1, b:2 }, { a:7, b:8 }, { a:6, b: 4}]);
+    coll.insert([{ a: 3, b: 3 }, { a: 6, b: 7 }, { a: 1, b: 2 }, { a: 7, b: 8 }, { a: 6, b: 4 }]);
 
-    coll.findAndRemove({a:6});
+    coll.findAndRemove({ a: 6 });
 
     expect(coll.data.length).toEqual(3);
 
@@ -64,12 +64,12 @@ describe('collection', function () {
     expect(result[2].b).toEqual(8);
   });
 
-  it('removeWhere works', function() {
+  it('removeWhere works', function () {
     var db = new loki('test.db');
     var coll = db.addCollection('testcoll');
-    coll.insert([{ a:3, b:3 }, { a:6, b:7 }, { a:1, b:2 }, { a:7, b:8 }, { a:6, b: 4}]);
+    coll.insert([{ a: 3, b: 3 }, { a: 6, b: 7 }, { a: 1, b: 2 }, { a: 7, b: 8 }, { a: 6, b: 4 }]);
 
-    coll.removeWhere(function(obj) {
+    coll.removeWhere(function (obj) {
       return obj.a === 6;
     });
 
@@ -82,18 +82,18 @@ describe('collection', function () {
     expect(result[2].b).toEqual(8);
   });
 
-  it('removeBatch works', function() {
+  it('removeBatch works', function () {
     var db = new loki('test.db');
     var coll = db.addCollection('testcoll');
-    coll.insert([{ a:3, b:3 }, { a:6, b:7 }, { a:1, b:2 }, { a:7, b:8 }, { a:6, b: 4}]);
+    coll.insert([{ a: 3, b: 3 }, { a: 6, b: 7 }, { a: 1, b: 2 }, { a: 7, b: 8 }, { a: 6, b: 4 }]);
 
     // remove by sending array of docs to remove()
-    var results = coll.find({ a: 6});
+    var results = coll.find({ a: 6 });
     expect(results.length).toEqual(2);
 
     coll.remove(results);
     expect(coll.data.length).toEqual(3);
-    
+
     results = coll.chain().find().simplesort("b").data();
     expect(results.length).toEqual(3);
     expect(results[0].b).toEqual(2);
@@ -102,8 +102,8 @@ describe('collection', function () {
 
     // now repeat but send $loki id array to remove()
     coll.clear();
-    coll.insert([{ a:3, b:3 }, { a:6, b:7 }, { a:1, b:2 }, { a:7, b:8 }, { a:6, b: 4}]);
-    results = coll.find({a: 6}).map(function (obj) { return obj.$loki });
+    coll.insert([{ a: 3, b: 3 }, { a: 6, b: 7 }, { a: 1, b: 2 }, { a: 7, b: 8 }, { a: 6, b: 4 }]);
+    results = coll.find({ a: 6 }).map(function (obj) { return obj.$loki; });
     expect(results.length).toEqual(2);
     coll.remove(results);
     results = coll.chain().find().simplesort("b").data();
@@ -113,18 +113,18 @@ describe('collection', function () {
     expect(results[2].b).toEqual(8);
   });
 
-  it('updateWhere works', function() {
+  it('updateWhere works', function () {
     var db = new loki('test.db');
     var coll = db.addCollection('testcoll');
-    coll.insert([{ a:3, b:3 }, { a:6, b:7 }, { a:1, b:2 }, { a:7, b:8 }, { a:6, b: 4}]);
+    coll.insert([{ a: 3, b: 3 }, { a: 6, b: 7 }, { a: 1, b: 2 }, { a: 7, b: 8 }, { a: 6, b: 4 }]);
 
     // guess we need to return object for this to work
-    coll.updateWhere(function(fobj) {return fobj.a===6}, function(obj) {
+    coll.updateWhere(function (fobj) { return fobj.a === 6; }, function (obj) {
       obj.b += 1;
       return obj;
     });
 
-    var result = coll.chain().find({a:6}).simplesort("b").data();
+    var result = coll.chain().find({ a: 6 }).simplesort("b").data();
     expect(result.length).toEqual(2);
     expect(result[0].b).toEqual(5);
     expect(result[1].b).toEqual(8);
@@ -132,10 +132,10 @@ describe('collection', function () {
 
   // coll.mode(property) should return single value of property which occurs most in collection
   // if more than one value 'ties' it will just pick one
-  it('mode works', function() {
+  it('mode works', function () {
     var db = new loki('test.db');
     var coll = db.addCollection('testcoll');
-    coll.insert([{ a:3, b:3 }, { a:6, b:7 }, { a:1, b:2 }, { a:7, b:8 }, { a:6, b: 4}]);
+    coll.insert([{ a: 3, b: 3 }, { a: 6, b: 7 }, { a: 1, b: 2 }, { a: 7, b: 8 }, { a: 6, b: 4 }]);
 
     // seems mode returns string so loose equality
     var result = coll.mode('a') == 6;
@@ -143,23 +143,23 @@ describe('collection', function () {
     expect(result).toEqual(true);
   });
 
-  it('single inserts emit with meta when async listeners false', function() {
+  it('single inserts emit with meta when async listeners false', function () {
     var db = new loki('test.db');
     var coll = db.addCollection('testcoll');
-    
-    // listen for insert events to validate objects
-    coll.on("insert", function(obj) {
-      expect(obj.hasOwnProperty('a')).toEqual(true);
-      expect([3,6,1,7,5].indexOf(obj.a)).toBeGreaterThan(-1);
 
-      switch(obj.a) {
+    // listen for insert events to validate objects
+    coll.on("insert", function (obj) {
+      expect(obj.hasOwnProperty('a')).toEqual(true);
+      expect([3, 6, 1, 7, 5].indexOf(obj.a)).toBeGreaterThan(-1);
+
+      switch (obj.a) {
         case 3: expect(obj.b).toEqual(3); break;
         case 6: expect(obj.b).toEqual(7); break;
         case 1: expect(obj.b).toEqual(2); break;
         case 7: expect(obj.b).toEqual(8); break;
         case 5: expect(obj.b).toEqual(4); break;
       };
-      
+
       expect(obj.hasOwnProperty('$loki')).toEqual(true);
       expect(obj.hasOwnProperty('meta')).toEqual(true);
       expect(obj.meta.hasOwnProperty('revision')).toEqual(true);
@@ -170,30 +170,30 @@ describe('collection', function () {
       expect(obj.meta.created).toBeGreaterThan(0);
     });
 
-    coll.insert({ a:3, b:3 });
-    coll.insert({ a:6, b:7 });
-    coll.insert({ a:1, b:2 });
-    coll.insert({ a:7, b:8 });
-    coll.insert({ a:5, b:4 });
+    coll.insert({ a: 3, b: 3 });
+    coll.insert({ a: 6, b: 7 });
+    coll.insert({ a: 1, b: 2 });
+    coll.insert({ a: 7, b: 8 });
+    coll.insert({ a: 5, b: 4 });
   });
-  
-  it('single inserts (with clone) emit meta and return instances correctly', function() {
-    var db = new loki('test.db');
-    var coll = db.addCollection('testcoll', { clone:true });
-    
-    // listen for insert events to validate objects
-    coll.on("insert", function(obj) {
-      expect(obj.hasOwnProperty('a')).toEqual(true);
-      expect([3,6,1,7,5].indexOf(obj.a)).toBeGreaterThan(-1);
 
-      switch(obj.a) {
+  it('single inserts (with clone) emit meta and return instances correctly', function () {
+    var db = new loki('test.db');
+    var coll = db.addCollection('testcoll', { clone: true });
+
+    // listen for insert events to validate objects
+    coll.on("insert", function (obj) {
+      expect(obj.hasOwnProperty('a')).toEqual(true);
+      expect([3, 6, 1, 7, 5].indexOf(obj.a)).toBeGreaterThan(-1);
+
+      switch (obj.a) {
         case 3: expect(obj.b).toEqual(3); break;
         case 6: expect(obj.b).toEqual(7); break;
         case 1: expect(obj.b).toEqual(2); break;
         case 7: expect(obj.b).toEqual(8); break;
         case 5: expect(obj.b).toEqual(4); break;
       };
-      
+
       expect(obj.hasOwnProperty('$loki')).toEqual(true);
       expect(obj.hasOwnProperty('meta')).toEqual(true);
       expect(obj.meta.hasOwnProperty('revision')).toEqual(true);
@@ -204,24 +204,24 @@ describe('collection', function () {
       expect(obj.meta.created).toBeGreaterThan(0);
     });
 
-    var i1 = coll.insert({ a:3, b:3 });
-    coll.insert({ a:6, b:7 });
-    coll.insert({ a:1, b:2 });
-    coll.insert({ a:7, b:8 });
-    coll.insert({ a:5, b:4 });
+    var i1 = coll.insert({ a: 3, b: 3 });
+    coll.insert({ a: 6, b: 7 });
+    coll.insert({ a: 1, b: 2 });
+    coll.insert({ a: 7, b: 8 });
+    coll.insert({ a: 5, b: 4 });
 
     // verify that the objects returned from an insert are clones by tampering with values
     i1.b = 9;
-    var result = coll.findOne({a:3});
+    var result = coll.findOne({ a: 3 });
     expect(result.b).toEqual(3);
   });
 
-  it('batch inserts emit with meta', function() {
+  it('batch inserts emit with meta', function () {
     var db = new loki('test.db');
     var coll = db.addCollection('testcoll');
 
     // listen for insert events to validate objects
-    coll.on("insert", function(objs) {
+    coll.on("insert", function (objs) {
       expect(Array.isArray(objs)).toEqual(true);
       expect(objs.length).toEqual(5);
 
@@ -251,15 +251,15 @@ describe('collection', function () {
       expect(objs[0].meta.created).toBeGreaterThan(0);
     });
 
-    coll.insert([{ a:3, b:3 },{ a:6, b:7 },{ a:1, b:2 },{ a:7, b:8 },{ a:5, b:4 }]);
+    coll.insert([{ a: 3, b: 3 }, { a: 6, b: 7 }, { a: 1, b: 2 }, { a: 7, b: 8 }, { a: 5, b: 4 }]);
   });
 
-  it('batch inserts emit with meta and return clones', function() {
+  it('batch inserts emit with meta and return clones', function () {
     var db = new loki('test.db');
-    var coll = db.addCollection('testcoll', { clone:true });
+    var coll = db.addCollection('testcoll', { clone: true });
 
     // listen for insert events to validate objects
-    coll.on("insert", function(objs) {
+    coll.on("insert", function (objs) {
       expect(Array.isArray(objs)).toEqual(true);
       expect(objs.length).toEqual(5);
 
@@ -289,9 +289,9 @@ describe('collection', function () {
       expect(objs[0].meta.created).toBeGreaterThan(0);
     });
 
-    var obj1 = { a:3, b: 3};
-    var result = coll.insert([obj1,{ a:6, b:7 },{ a:1, b:2 },{ a:7, b:8 },{ a:5, b:4 }]);
-    
+    var obj1 = { a: 3, b: 3 };
+    var result = coll.insert([obj1, { a: 6, b: 7 }, { a: 1, b: 2 }, { a: 7, b: 8 }, { a: 5, b: 4 }]);
+
     expect(Array.isArray(result)).toEqual(true);
 
     // tamper original (after insert)
@@ -300,8 +300,321 @@ describe('collection', function () {
     expect(result[0].b).toEqual(3);
 
     // internal data references should have benn clones of original
-    var obj = coll.findOne({a:3});
+    var obj = coll.findOne({ a: 3 });
     expect(obj.b).toEqual(3);
   });
 
+  describe('case sensitive and insensitive filtering', () => {
+    const fixture = [{ a: 'a', b: 7 }, { a: 'B', b: 2 }, { a: 'c', b: 8 }, { a: 'D', b: 4 }];
+
+    describe('case sensitive', () => {
+
+      it('case sensitive $gt', function () {
+        var db = new loki();
+        var coll = db.addCollection('testcoll', { clone: true });
+        coll.insert(fixture);
+        var result = coll.find({ a: { $gt: 'A' } });
+        expect(result).toEqual([
+          expect.objectContaining({ a: "a", }),
+          expect.objectContaining({ a: "B", }),
+          expect.objectContaining({ a: "c", }),
+          expect.objectContaining({ a: "D", }),
+        ]);
+
+        result = coll.find({ a: { $gt: 'a' } });
+        expect(result).toEqual([
+          expect.objectContaining({ a: "c", }),
+        ]);
+      });
+
+      it('case sensitive $lt', function () {
+        var db = new loki();
+        var coll = db.addCollection('testcoll', { clone: true });
+        coll.insert(fixture);
+        var result = coll.find({ a: { $lt: 'c' } });
+        expect(result).toEqual([
+          expect.objectContaining({ a: "a", }),
+          expect.objectContaining({ a: "B", }),
+          expect.objectContaining({ a: "D", }),
+        ]);
+
+        result = coll.find({ a: { $lt: 'D' } });
+        expect(result).toEqual([
+          expect.objectContaining({ a: "B", }),
+        ]);
+      });
+
+      it('case sensitive $gte', function () {
+        var db = new loki();
+        var coll = db.addCollection('testcoll', { clone: true });
+        coll.insert(fixture);
+        var result = coll.find({ a: { $gte: 'A' } });
+        expect(result).toEqual([
+          expect.objectContaining({ a: "a", }),
+          expect.objectContaining({ a: "B", }),
+          expect.objectContaining({ a: "c", }),
+          expect.objectContaining({ a: "D", }),
+        ]);
+
+        result = coll.find({ a: { $gt: 'a' } });
+        expect(result).toEqual([
+          expect.objectContaining({ a: "c", }),
+        ]);
+      });
+
+      it('case sensitive $lte', function () {
+        var db = new loki();
+        var coll = db.addCollection('testcoll', { clone: true });
+        coll.insert(fixture);
+        var result = coll.find({ a: { $lte: 'D' } });
+        expect(result).toEqual([
+          expect.objectContaining({ a: "B", }),
+          expect.objectContaining({ a: "D", }),
+        ]);
+
+        result = coll.find({ a: { $lte: 'B' } });
+        expect(result).toEqual([
+          expect.objectContaining({ a: "B", }),
+        ]);
+      });
+    });
+
+    describe('case insensitive', () => {
+      it('case insensitive $gt', function () {
+        var db = new loki();
+        var coll = db.addCollection('testcoll', { clone: true, caseInsensitive: true });
+        coll.insert(fixture);
+        var result = coll.find({ a: { $gt: 'a' } });
+        expect(result).toEqual([
+          //expect.objectContaining({ a: "a", }),
+          expect.objectContaining({ a: "B", }),
+          expect.objectContaining({ a: "c", }),
+          expect.objectContaining({ a: "D", }),
+        ]);
+
+        result = coll.find({ a: { $gt: 'c' } });
+        expect(result).toEqual([
+          expect.objectContaining({ a: "D", }),
+        ]);
+      });
+
+      it('case insensitive $lt', function () {
+        var db = new loki();
+        var coll = db.addCollection('testcoll', { clone: true, caseInsensitive: true });
+        coll.insert(fixture);
+        var result = coll.find({ a: { $lt: 'c' } });
+        expect(result).toEqual([
+          expect.objectContaining({ a: "a", }),
+          expect.objectContaining({ a: "B", }),
+        ]);
+
+        result = coll.find({ a: { $lt: 'D' } });
+        expect(result).toEqual([
+          expect.objectContaining({ a: "a", }),
+          expect.objectContaining({ a: "B", }),
+          expect.objectContaining({ a: "c", }),
+        ]);
+      });
+
+      it('case insensitive $gte', function () {
+        var db = new loki();
+        var coll = db.addCollection('testcoll', { clone: true, caseInsensitive: true });
+        coll.insert(fixture);
+        var result = coll.find({ a: { $gte: 'A' } });
+        expect(result).toEqual([
+          expect.objectContaining({ a: "a", }),
+          expect.objectContaining({ a: "B", }),
+          expect.objectContaining({ a: "c", }),
+          expect.objectContaining({ a: "D", }),
+        ]);
+
+        result = coll.find({ a: { $gte: 'a' } });
+        expect(result).toEqual([
+          expect.objectContaining({ a: "a", }),
+          expect.objectContaining({ a: "B", }),
+          expect.objectContaining({ a: "c", }),
+          expect.objectContaining({ a: "D", }),
+        ]);
+      });
+
+      it('case insensitive $lte', function () {
+        var db = new loki();
+        var coll = db.addCollection('testcoll', { clone: true, caseInsensitive: true });
+        coll.insert(fixture);
+        var result = coll.find({ a: { $lte: 'D' } });
+        expect(result).toEqual([
+          expect.objectContaining({ a: "a", }),
+          expect.objectContaining({ a: "B", }),
+          expect.objectContaining({ a: "c", }),
+          expect.objectContaining({ a: "D", }),
+        ]);
+
+        result = coll.find({ a: { $lte: 'D' } });
+        expect(result).toEqual([
+          expect.objectContaining({ a: "a", }),
+          expect.objectContaining({ a: "B", }),
+          expect.objectContaining({ a: "c", }),
+          expect.objectContaining({ a: "D", }),
+        ]);
+      });
+    });
+  });
+  describe('case sensitive and insensitive filtering on dot dot subpath', () => {
+    const fixture = [
+      { d: { c: { a: 'a', b: 7 } } },
+      { d: { c: { a: 'B', b: 2 } } },
+      { d: { c: { a: 'c', b: 8 } } },
+      { d: { c: { a: 'D', b: 4 } } }];
+
+    describe('case sensitive', () => {
+
+      it('case sensitive $gt', function () {
+        var db = new loki();
+        var coll = db.addCollection('testcoll', { clone: true });
+        coll.insert(fixture);
+        var result = coll.find({ 'd.c.a': { $gt: 'A' } });
+        expect(result).toEqual([
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "a", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "B", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "c", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "D", }) }) }),
+        ]);
+
+        result = coll.find({ 'd.c.a': { $gt: 'a' } });
+        expect(result).toEqual([
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "c", }) }) }),
+        ]);
+      });
+
+      it('case sensitive $lt', function () {
+        var db = new loki();
+        var coll = db.addCollection('testcoll', { clone: true });
+        coll.insert(fixture);
+        var result = coll.find({ 'd.c.a': { $lt: 'c' } });
+        expect(result).toEqual([
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "a", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "B", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "D", }) }) }),
+        ]);
+
+        result = coll.find({ 'd.c.a': { $lt: 'D' } });
+        expect(result).toEqual([
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "B", }) }) }),
+        ]);
+      });
+
+      it('case sensitive $gte', function () {
+        var db = new loki();
+        var coll = db.addCollection('testcoll', { clone: true });
+        coll.insert(fixture);
+        var result = coll.find({ 'd.c.a': { $gte: 'A' } });
+        expect(result).toEqual([
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "a", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "B", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "c", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "D", }) }) }),
+        ]);
+
+        result = coll.find({ 'd.c.a': { $gt: 'a' } });
+        expect(result).toEqual([
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "c", }) }) }),
+        ]);
+      });
+
+      it('case sensitive $lte', function () {
+        var db = new loki();
+        var coll = db.addCollection('testcoll', { clone: true });
+        coll.insert(fixture);
+        var result = coll.find({ 'd.c.a': { $lte: 'D' } });
+        expect(result).toEqual([
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "B", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "D", }) }) }),
+        ]);
+
+        result = coll.find({ 'd.c.a': { $lte: 'B' } });
+        expect(result).toEqual([
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "B", }) }) }),
+        ]);
+      });
+    });
+
+    describe('case insensitive', () => {
+      it('case insensitive $gt', function () {
+        var db = new loki();
+        var coll = db.addCollection('testcoll', { clone: true, caseInsensitive: true });
+        coll.insert(fixture);
+        var result = coll.find({ 'd.c.a': { $gt: 'a' } });
+        expect(result).toEqual([
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "B", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "c", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "D", }) }) }),
+        ]);
+
+        result = coll.find({ 'd.c.a': { $gt: 'c' } });
+        expect(result).toEqual([
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "D", }) }) }),
+        ]);
+      });
+
+      it('case insensitive $lt', function () {
+        var db = new loki();
+        var coll = db.addCollection('testcoll', { clone: true, caseInsensitive: true });
+        coll.insert(fixture);
+        var result = coll.find({ 'd.c.a': { $lt: 'c' } });
+        expect(result).toEqual([
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "a", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "B", }) }) }),
+        ]);
+
+        result = coll.find({ 'd.c.a': { $lt: 'D' } });
+        expect(result).toEqual([
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "a", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "B", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "c", }) }) }),
+        ]);
+      });
+
+      it('case insensitive $gte', function () {
+        var db = new loki();
+        var coll = db.addCollection('testcoll', { clone: true, caseInsensitive: true });
+        coll.insert(fixture);
+        var result = coll.find({ 'd.c.a': { $gte: 'A' } });
+        expect(result).toEqual([
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "a", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "B", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "c", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "D", }) }) }),
+        ]);
+
+        result = coll.find({ 'd.c.a': { $gte: 'a' } });
+        expect(result).toEqual([
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "a", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "B", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "c", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "D", }) }) }),
+        ]);
+      });
+
+      it('case insensitive $lte', function () {
+        var db = new loki();
+        var coll = db.addCollection('testcoll', { clone: true, caseInsensitive: true });
+        coll.insert(fixture);
+        var result = coll.find({ 'd.c.a': { $lte: 'D' } });
+        expect(result).toEqual([
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "a", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "B", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "c", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "D", }) }) }),
+        ]);
+
+        result = coll.find({ 'd.c.a': { $lte: 'D' } });
+        expect(result).toEqual([
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "a", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "B", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "c", }) }) }),
+          expect.objectContaining({ d: expect.objectContaining({ c: expect.objectContaining({ a: "D", }) }) }),
+        ]);
+      });
+    });
+  });
 });

--- a/types.d.ts
+++ b/types.d.ts
@@ -1408,6 +1408,7 @@ declare class Collection<E extends object> extends LokiEventEmitter {
     getChangeDelta: (obj: any, old?: any) => any;
     getObjectDelta: (oldObject: any, newObject?: any) => any;
     setChangesApi: (enabled?: boolean) => void;
+    caseInsensitive?:boolean;
 
     /**
      * @param name - collection name


### PR DESCRIPTION
In order to align with the server's gt and lt filter, I had to fork LokiJS and add an option to ignore the casing when comparing strings.